### PR TITLE
CI: remove push trigger to fix check name mismatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [master]
   pull_request:
     branches: [master]
 


### PR DESCRIPTION
GitHub appends "(pull_request)" suffix when both push and pull_request triggers exist, causing required status checks to never match.